### PR TITLE
Tested and fixed an issue for IE10.  Added BlobBuilder with MS prefix.

### DIFF
--- a/canvas-to-blob.js
+++ b/canvas-to-blob.js
@@ -20,7 +20,7 @@
     var CanvasPrototype = window.HTMLCanvasElement &&
             window.HTMLCanvasElement.prototype,
         BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder ||
-            window.MozBlobBuilder,
+            window.MozBlobBuilder || window.MSBlobBuilder,
         dataURLtoBlob = BlobBuilder && window.atob && window.ArrayBuffer &&
             window.Uint8Array && function (dataURI) {
                 var byteString,


### PR DESCRIPTION
IE10 now supports a prefixed version of BuildBuilder.
