### PR TITLE
Supporting 'quality' as a third parameter

### DIFF
--- a/canvas-to-blob.js
+++ b/canvas-to-blob.js
@@ -71,13 +71,13 @@
                 return bb.getBlob(mimeString);
             };
     if (window.HTMLCanvasElement && !CanvasPrototype.toBlob) {
-        if (CanvasPrototype.mozGetAsFile) {
+        if (CanvasPrototype.toDataURL && dataURLtoBlob) {
+            CanvasPrototype.toBlob = function (callback, type, quality) {
+                callback(dataURLtoBlob(this.toDataURL(type, quality)));
+            };
+        } else if (CanvasPrototype.mozGetAsFile) {
             CanvasPrototype.toBlob = function (callback, type) {
                 callback(this.mozGetAsFile('blob', type));
-            };
-        } else if (CanvasPrototype.toDataURL && dataURLtoBlob) {
-            CanvasPrototype.toBlob = function (callback, type) {
-                callback(dataURLtoBlob(this.toDataURL(type)));
             };
         }
     }


### PR DESCRIPTION
Hi, now support quality (0.0 to 1.0) as a third argument which is passed on to the toDataURL function. Also, toDataURL is available in most browsers, so give preference to that.
