### PR TITLE
Exposing license information according to bower format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,12 +26,7 @@
     "url": "git://github.com/blueimp/JavaScript-Canvas-to-Blob.git"
   },
   "bugs": "https://github.com/blueimp/JavaScript-Canvas-to-Blob/issues",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "js/canvas-to-blob.js",
   "ignore": [
     "/*.*",


### PR DESCRIPTION
`license` field should contain String or Array of Strings. See: http://bower.io/docs/creating-packages/

Current format doesn't work with libraries that inspect and generate information about all the libraries used in the project (e.g. `grunt-license-bower`).