### PR TITLE
Use proper end semicolon

### DIFF
--- a/js/canvas-to-blob.js
+++ b/js/canvas-to-blob.js
@@ -14,8 +14,8 @@
 
 /*global window, atob, Blob, ArrayBuffer, Uint8Array, define, module */
 
-;(function (window) {
-  'use strict'
+(function (window) {
+  'use strict';
 
   var CanvasPrototype = window.HTMLCanvasElement &&
                           window.HTMLCanvasElement.prototype
@@ -108,4 +108,4 @@
   } else {
     window.dataURLtoBlob = dataURLtoBlob
   }
-}(window))
+}(window));

--- a/js/canvas-to-blob.js
+++ b/js/canvas-to-blob.js
@@ -14,8 +14,8 @@
 
 /*global window, atob, Blob, ArrayBuffer, Uint8Array, define, module */
 
-(function (window) {
-  'use strict';
+;(function (window) {
+  'use strict'
 
   var CanvasPrototype = window.HTMLCanvasElement &&
                           window.HTMLCanvasElement.prototype


### PR DESCRIPTION
to be able to chain files via asset compress tools and avoid `TypeError: (intermediate value)(...) is not a function` error.