### PR TITLE
Support to load in node for server-side rendering

### DIFF
--- a/js/canvas-to-blob.js
+++ b/js/canvas-to-blob.js
@@ -123,4 +123,4 @@
   } else {
     window.dataURLtoBlob = dataURLtoBlob
   }
-})(window)
+})(this)


### PR DESCRIPTION
Some web projects may need to load this package in node (but not use it), this PR resolves the following error:

```text
ReferenceError: window is not defined
...
```